### PR TITLE
Add mouse click to select panes (#1)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -319,6 +319,7 @@ const AppContent = () => {
         onFavouriteChange={handleFavouriteChange}
         onFavouriteSelect={handleFavouriteSelect}
         onPayloadChange={(index) => dispatch({ type: "set", data: { selectedPayloadIndex: index, activePane: "payload" } })}
+        onPayloadFocus={() => dispatch({ type: "set", data: { activePane: "payload" } })}
         onWatchChange={(index) => dispatch({ type: "set", data: { selectedWatchIndex: index, activePane: "watchlist" } })}
         detailsTitle={selectedMessage ? `Details (${selectedMessage.topic})` : "Details"}
         detailsContent={detailsContent.content}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -171,7 +171,7 @@ const AppContent = () => {
   const handleFavouriteChange = (index: number) => {
     const fav = state.favourites[index];
     if (!fav) {
-      dispatch({ type: "set", data: { selectedFavouriteIndex: index } });
+      dispatch({ type: "set", data: { selectedFavouriteIndex: index, activePane: "favourites" } });
       return;
     }
     const topicIndex = topicTree.topicPaths.indexOf(fav.topic);
@@ -182,6 +182,7 @@ const AppContent = () => {
           selectedFavouriteIndex: index,
           selectedTopicIndex: topicIndex,
           selectedPayloadIndex: 0,
+          activePane: "favourites",
         },
       });
       return;
@@ -205,6 +206,7 @@ const AppContent = () => {
         selectedTopicIndex: nextIndex >= 0 ? nextIndex : state.selectedTopicIndex,
         selectedPayloadIndex: nextIndex >= 0 ? 0 : state.selectedPayloadIndex,
         topicExpansion: nextExpansion,
+        activePane: "favourites",
       },
     });
   };
@@ -311,13 +313,13 @@ const AppContent = () => {
         selectedPayloadIndex={state.selectedPayloadIndex}
         selectedWatchIndex={state.selectedWatchIndex}
         onTopicChange={(index) =>
-          dispatch({ type: "set", data: { selectedTopicIndex: index, selectedPayloadIndex: 0 } })
+          dispatch({ type: "set", data: { selectedTopicIndex: index, selectedPayloadIndex: 0, activePane: "topics" } })
         }
         onTopicSelect={handleTopicSelect}
         onFavouriteChange={handleFavouriteChange}
         onFavouriteSelect={handleFavouriteSelect}
-        onPayloadChange={(index) => dispatch({ type: "set", data: { selectedPayloadIndex: index } })}
-        onWatchChange={(index) => dispatch({ type: "set", data: { selectedWatchIndex: index } })}
+        onPayloadChange={(index) => dispatch({ type: "set", data: { selectedPayloadIndex: index, activePane: "payload" } })}
+        onWatchChange={(index) => dispatch({ type: "set", data: { selectedWatchIndex: index, activePane: "watchlist" } })}
         detailsTitle={selectedMessage ? `Details (${selectedMessage.topic})` : "Details"}
         detailsContent={detailsContent.content}
         detailsIsJson={detailsContent.isJson}

--- a/src/components/FavouritesPane.tsx
+++ b/src/components/FavouritesPane.tsx
@@ -1,5 +1,6 @@
 import type { SelectOption } from "@opentui/core";
 import { paneActiveBackground, paneInactiveBackground } from "../ui/paneTheme";
+import { selectMouseDown } from "../utils/mouseHandlers";
 
 type FavouritesPaneProps = {
   options: SelectOption[];
@@ -37,6 +38,7 @@ export const FavouritesPane = ({
           selectedIndex={Math.max(0, selectedIndex)}
           onChange={(index) => onChange(index)}
           onSelect={(index) => onSelect(index)}
+          onMouseDown={selectMouseDown}
           backgroundColor={focused ? paneActiveBackground : paneInactiveBackground}
           focusedBackgroundColor={paneActiveBackground}
           selectedBackgroundColor={focused ? "#2d8cff" : paneInactiveBackground}

--- a/src/components/PaneLayout.tsx
+++ b/src/components/PaneLayout.tsx
@@ -25,6 +25,7 @@ type PaneLayoutProps = {
   onFavouriteChange: (index: number) => void;
   onFavouriteSelect: (index: number) => void;
   onPayloadChange: (index: number) => void;
+  onPayloadFocus: () => void;
   onWatchChange: (index: number) => void;
   detailsTitle: string;
   detailsContent: string;
@@ -50,6 +51,7 @@ export const PaneLayout = ({
   onFavouriteChange,
   onFavouriteSelect,
   onPayloadChange,
+  onPayloadFocus,
   onWatchChange,
   detailsTitle,
   detailsContent,
@@ -75,6 +77,7 @@ export const PaneLayout = ({
             focused={activePane === "payload"}
             count={payloadCount}
             onChange={onPayloadChange}
+            onFocus={onPayloadFocus}
           />
         </box>
         <box style={{ flexGrow: 1 }}>

--- a/src/components/TopicsPane.tsx
+++ b/src/components/TopicsPane.tsx
@@ -1,5 +1,6 @@
 import type { SelectOption } from "@opentui/core";
 import { paneActiveBackground } from "../ui/paneTheme";
+import { selectMouseDown } from "../utils/mouseHandlers";
 
 type TopicsPaneProps = {
   options: SelectOption[];
@@ -34,6 +35,7 @@ export const TopicsPane = ({
         selectedIndex={selectedIndex}
         onChange={(index) => onChange(index)}
         onSelect={(index) => onSelect(index)}
+        onMouseDown={selectMouseDown}
         showDescription={false}
         backgroundColor={focused ? paneActiveBackground : undefined}
         focusedBackgroundColor={paneActiveBackground}

--- a/src/components/WatchlistPane.tsx
+++ b/src/components/WatchlistPane.tsx
@@ -1,5 +1,6 @@
 import type { SelectOption } from "@opentui/core";
 import { paneActiveBackground, paneInactiveBackground } from "../ui/paneTheme";
+import { selectMouseDown } from "../utils/mouseHandlers";
 
 type WatchlistPaneProps = {
   options: SelectOption[];
@@ -28,6 +29,7 @@ export const WatchlistPane = ({ options, selectedIndex, focused, count, onChange
           focused={focused}
           selectedIndex={Math.max(0, selectedIndex)}
           onChange={(index) => onChange(index)}
+          onMouseDown={selectMouseDown}
           backgroundColor={focused ? paneActiveBackground : paneInactiveBackground}
           focusedBackgroundColor={paneActiveBackground}
           selectedBackgroundColor={focused ? "#2d8cff" : paneInactiveBackground}

--- a/src/dialogs/HelpDialog.tsx
+++ b/src/dialogs/HelpDialog.tsx
@@ -41,7 +41,7 @@ export const HelpDialog = () => {
       }}
     >
       <text
-        content={`Global\n\n- Tab / Shift+Tab cycle sections (1→2→3→4→5)\n- 1 Topics, 2 Payload, 3 Details, 4 Favourites, 5 Watchlist\n- j/k or ↓/↑ move selection\n- h/l or ←/→ collapse/expand tree\n- b broker config\n- / search topics\n- f exclude filters\n- n publish new\n- p pause/resume updates\n- ? help\n- q quit\n\nTopics\n- space toggle favourite (leaf topics)\n\nFavourites\n- space remove favourite\n- r rename favourite\n\nPayload\n- space toggle watchlist\n\nWatchlist\n- space remove watch entry\n\nDetails\n- e edit and publish\n\nDialogs\n- Tab/Shift+Tab change field\n- Ctrl+k clear payload\n- Ctrl+x clear all fields\n- Ctrl+t focus topic\n- Ctrl+s save message\n- Ctrl+l focus saved list\n- Enter confirm\n- Esc cancel`}
+        content={`Global\n\n- Tab / Shift+Tab cycle sections (1→2→3→4→5)\n- 1 Topics, 2 Payload, 3 Details, 4 Favourites, 5 Watchlist\n- j/k or ↓/↑ move selection\n- h/l or ←/→ collapse/expand tree\n- b broker config\n- / search topics\n- f exclude filters\n- n publish new\n- p pause/resume updates\n- ? help\n- q quit\n\nMouse\n- Click a list item to focus that pane and select it\n- Scroll wheel to navigate lists\n\nTopics\n- space toggle favourite (leaf topics)\n\nFavourites\n- space remove favourite\n- r rename favourite\n\nPayload\n- space toggle watchlist\n\nWatchlist\n- space remove watch entry\n\nDetails\n- e edit and publish\n\nDialogs\n- Tab/Shift+Tab change field\n- Ctrl+k clear payload\n- Ctrl+x clear all fields\n- Ctrl+t focus topic\n- Ctrl+s save message\n- Ctrl+l focus saved list\n- Enter confirm\n- Esc cancel`}
         fg="#cbd5f5"
       />
     </box>

--- a/src/utils/mouseHandlers.ts
+++ b/src/utils/mouseHandlers.ts
@@ -1,0 +1,40 @@
+import type { SelectRenderable, MouseEvent } from "@opentui/core";
+
+/**
+ * onMouseDown handler for <select> elements.
+ *
+ * MUST be a regular `function` (not an arrow function) because opentui calls
+ * mouse handlers via `.call(this, event)` where `this` is the SelectRenderable
+ * instance. Arrow functions capture `this` lexically and would ignore the binding.
+ *
+ * When the user clicks on a SelectRenderable, opentui has no built-in item
+ * selection logic — it only auto-focuses the element. This handler calculates
+ * which item the user clicked (using the element's scroll offset, per-item
+ * line height, and the click's local Y coordinate), then calls:
+ *
+ *   - `setSelectedIndex(idx)`  → emits SELECTION_CHANGED → triggers `onChange`
+ *   - `selectCurrent()`        → emits ITEM_SELECTED    → triggers `onSelect`
+ *
+ * The `onChange` callback (wired in App.tsx) dispatches `{ activePane, selectedXIndex }`
+ * so React state is updated before the next render, preventing the race condition
+ * where React would re-render with `focused={false}` and immediately undo
+ * opentui's auto-focus.
+ */
+export const selectMouseDown: (this: SelectRenderable, event: MouseEvent) => void =
+  function (this: SelectRenderable, event: MouseEvent) {
+    // Access private runtime fields via `any` — they are not in the public API
+    // but are stable implementation details of SelectRenderable.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const self = this as any;
+
+    const rendererY: number = self.y as number;
+    const scrollOffset: number = (self.scrollOffset as number) || 0;
+    const linesPerItem: number = (self.linesPerItem as number) || 1;
+
+    const localY = event.y - rendererY;
+    const clickedIndex = scrollOffset + Math.floor(localY / linesPerItem);
+    const clampedIndex = Math.max(0, Math.min(clickedIndex, this.options.length - 1));
+
+    this.setSelectedIndex(clampedIndex);
+    this.selectCurrent();
+  };


### PR DESCRIPTION
Closes #1

Clicking any list item in Topics, Payload, Favourites, or Watchlist now automatically focuses that pane.

- All pane `onChange` callbacks now dispatch `activePane` on click
- Added Mouse section to the Help dialog documenting click-to-focus and scroll behaviour