### PR TITLE
Add multiple simultaneous subscriptions (#3)

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -179,6 +179,9 @@ if (overrides.user !== undefined) process.env.TERMOTTQ_USER = overrides.user;
 if (overrides.password !== undefined) process.env.TERMOTTQ_PASSWORD = overrides.password;
 if (overrides.tls) process.env.TERMOTTQ_TLS = "true";
 if (overrides.rootTopic) process.env.TERMOTTQ_ROOT_TOPIC = overrides.rootTopic;
+if (overrides.extraTopics && overrides.extraTopics.length > 0) {
+  process.env.TERMOTTQ_EXTRA_TOPICS = overrides.extraTopics.join(",");
+}
 
 await ensureTreeSitterWorker();
 const renderer = await createCliRenderer({ exitOnCtrlC: true });

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -150,7 +150,8 @@ export const getWatchOptions = (state: AppState) => {
 
 export const getStatusLine = (state: AppState) => {
   const status = state.connectionStatus.toUpperCase();
-  const host = `${state.broker.host}:${state.broker.port}`;
+  const extraCount = (state.broker.topicFilters ?? []).filter((f) => f.trim().length > 0).length;
+  const topicLabel = extraCount > 0 ? `${state.broker.host}:${state.broker.port} (${1 + extraCount} topics)` : `${state.broker.host}:${state.broker.port}`;
   const searchActive = state.searchQuery.trim().length > 0;
   const search = searchActive ? `search:${state.searchQuery}` : "search:off";
   const excludesCount = state.excludeFilters.filter((f) => f.enabled).length;
@@ -159,7 +160,7 @@ export const getStatusLine = (state: AppState) => {
   const debug = state.debugKeys && state.lastKeyDebug ? `key:${state.lastKeyDebug}` : "";
   return {
     status,
-    host,
+    host: topicLabel,
     search,
     searchActive,
     excludes,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,8 @@ export type CliOverrides = {
   password?: string;
   tls?: boolean;
   rootTopic?: string;
+  /** Additional topic subscriptions (beyond the primary rootTopic). */
+  extraTopics?: string[];
 };
 
 export type ClearStorageOptions = {
@@ -91,7 +93,13 @@ export const parseArgs = (args: string[]): CliParseResult => {
       continue;
     }
     if (arg === "--root-topic" || arg === "-r") {
-      if (next) overrides.rootTopic = next;
+      if (next) {
+        if (!overrides.rootTopic) {
+          overrides.rootTopic = next;
+        } else {
+          overrides.extraTopics = [...(overrides.extraTopics ?? []), next];
+        }
+      }
       i += 1;
       continue;
     }
@@ -116,10 +124,11 @@ Options:
   -u, --user <user>        Username
   -w, --password <pass>    Password
   -t, --tls                Enable TLS
-  -r, --root-topic <topic> Root topic (subscribe filter)
+  -r, --root-topic <topic> Root topic (subscribe filter); repeat for multiple
 
 Examples:
   termqtt -b localhost -P 1883 -r sensors/#
+  termqtt -b localhost -r sensors/# -r devices/# -r alerts/#
   termqtt --broker mqtt.example.com --tls --user alice --password secret -r devices/#
 `;
 

--- a/src/dialogs/BrokerDialog.tsx
+++ b/src/dialogs/BrokerDialog.tsx
@@ -9,6 +9,16 @@ type BrokerDialogProps = {
   onSave: (broker: BrokerConfig) => void;
 };
 
+/** Serialize extra topic filters as a comma-separated string for display in the input. */
+const filtersToString = (filters: string[]): string => filters.join(", ");
+
+/** Parse a comma-separated or newline-separated string into a topic filter list. */
+const stringToFilters = (value: string): string[] =>
+  value
+    .split(/[,\n]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
 export const BrokerDialog = ({ initialBroker, onSave }: BrokerDialogProps) => {
   const { closeDialog } = useDialog();
   const [broker, setBroker] = useState<BrokerConfig>(initialBroker);
@@ -41,6 +51,12 @@ export const BrokerDialog = ({ initialBroker, onSave }: BrokerDialogProps) => {
         label: "Root topic",
         value: broker.topicFilter,
         set: (value: string) => setBroker((prev) => ({ ...prev, topicFilter: value })),
+      },
+      {
+        label: "Extra topics (comma-sep)",
+        value: filtersToString(broker.topicFilters),
+        set: (value: string) =>
+          setBroker((prev) => ({ ...prev, topicFilters: stringToFilters(value) })),
       },
       {
         label: "TLS (true/false)",
@@ -98,6 +114,8 @@ export const BrokerDialog = ({ initialBroker, onSave }: BrokerDialogProps) => {
     handleKey(key);
   });
 
+  const activeFilterCount = broker.topicFilters.filter((f) => f.trim().length > 0).length + 1;
+
   return (
     <box
       title="Broker Configuration"
@@ -105,7 +123,7 @@ export const BrokerDialog = ({ initialBroker, onSave }: BrokerDialogProps) => {
       style={{
         position: "absolute",
         width: "70%",
-        height: "70%",
+        height: "80%",
         left: "15%",
         top: "10%",
         borderStyle: "double",
@@ -147,6 +165,12 @@ export const BrokerDialog = ({ initialBroker, onSave }: BrokerDialogProps) => {
           ))}
         </box>
       </scrollbox>
+      {activeFilterCount > 1 && (
+        <text
+          content={`Subscribing to ${activeFilterCount} topic filters`}
+          fg="#60a5fa"
+        />
+      )}
       <text
         content="Tab/Shift+Tab fields • Enter save • Esc close"
         fg="#94a3b8"

--- a/src/dialogs/HelpDialog.tsx
+++ b/src/dialogs/HelpDialog.tsx
@@ -41,7 +41,7 @@ export const HelpDialog = () => {
       }}
     >
       <text
-        content={`Global\n\n- Tab / Shift+Tab cycle sections (1→2→3→4→5)\n- 1 Topics, 2 Payload, 3 Details, 4 Favourites, 5 Watchlist\n- j/k or ↓/↑ move selection\n- h/l or ←/→ collapse/expand tree\n- b broker config\n- / search topics\n- f exclude filters\n- n publish new\n- p pause/resume updates\n- ? help\n- q quit\n\nTopics\n- space toggle favourite (leaf topics)\n\nFavourites\n- space remove favourite\n- r rename favourite\n\nPayload\n- space toggle watchlist\n\nWatchlist\n- space remove watch entry\n\nDetails\n- e edit and publish\n\nDialogs\n- Tab/Shift+Tab change field\n- Ctrl+k clear payload\n- Ctrl+x clear all fields\n- Ctrl+t focus topic\n- Ctrl+s save message\n- Ctrl+l focus saved list\n- Enter confirm\n- Esc cancel`}
+        content={`Global\n\n- Tab / Shift+Tab cycle sections (1→2→3→4→5)\n- 1 Topics, 2 Payload, 3 Details, 4 Favourites, 5 Watchlist\n- j/k or ↓/↑ move selection\n- h/l or ←/→ collapse/expand tree\n- b broker config (Extra topics field supports multiple, comma-separated)\n- / search topics\n- f exclude filters\n- n publish new\n- p pause/resume updates\n- ? help\n- q quit\n\nTopics\n- space toggle favourite (leaf topics)\n\nFavourites\n- space remove favourite\n- r rename favourite\n\nPayload\n- space toggle watchlist\n\nWatchlist\n- space remove watch entry\n\nDetails\n- e edit and publish\n\nDialogs\n- Tab/Shift+Tab change field\n- Ctrl+k clear payload\n- Ctrl+x clear all fields\n- Ctrl+t focus topic\n- Ctrl+s save message\n- Ctrl+l focus saved list\n- Enter confirm\n- Esc cancel`}
         fg="#cbd5f5"
       />
     </box>

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -28,6 +28,9 @@ const normalizeBrokerConfig = (value: unknown, fallback: BrokerConfig): BrokerCo
   const port = Number(partial.port ?? fallback.port);
   const qosValue = Number(partial.qos ?? fallback.qos);
   const qos = qosValue === 1 || qosValue === 2 ? (qosValue as 1 | 2) : 0;
+  const topicFilters = Array.isArray(partial.topicFilters)
+    ? (partial.topicFilters as unknown[]).filter((f): f is string => typeof f === "string")
+    : fallback.topicFilters;
   return {
     ...fallback,
     ...partial,
@@ -37,6 +40,7 @@ const normalizeBrokerConfig = (value: unknown, fallback: BrokerConfig): BrokerCo
     username: typeof partial.username === "string" ? partial.username : fallback.username,
     password: typeof partial.password === "string" ? partial.password : fallback.password,
     topicFilter: typeof partial.topicFilter === "string" ? partial.topicFilter : fallback.topicFilter,
+    topicFilters,
     defaultTopic: typeof partial.defaultTopic === "string" ? partial.defaultTopic : fallback.defaultTopic,
     tls: typeof partial.tls === "boolean" ? partial.tls : fallback.tls,
     qos,

--- a/src/state.ts
+++ b/src/state.ts
@@ -4,7 +4,10 @@ export type BrokerConfig = {
   clientId: string;
   username: string;
   password: string;
+  /** Primary (first) topic filter — kept for backward compatibility */
   topicFilter: string;
+  /** Additional topic filters. When non-empty, all entries (including topicFilter) are subscribed. */
+  topicFilters: string[];
   defaultTopic: string;
   tls: boolean;
   qos: 0 | 1 | 2;
@@ -77,6 +80,7 @@ export const createDefaultBrokerConfig = (): BrokerConfig => ({
   username: "",
   password: "",
   topicFilter: "#",
+  topicFilters: [],
   defaultTopic: "",
   tls: false,
   qos: 0,
@@ -86,6 +90,9 @@ const resolveDefaultBrokerConfig = () => {
   const defaults = createDefaultBrokerConfig();
   const rootTopic = Bun.env.TERMOTTQ_ROOT_TOPIC || defaults.topicFilter;
   const port = Bun.env.TERMOTTQ_PORT ? Number(Bun.env.TERMOTTQ_PORT) : defaults.port;
+  const extraTopics = Bun.env.TERMOTTQ_EXTRA_TOPICS
+    ? Bun.env.TERMOTTQ_EXTRA_TOPICS.split(",").map((t) => t.trim()).filter((t) => t.length > 0)
+    : defaults.topicFilters;
   return {
     ...defaults,
     host: Bun.env.TERMOTTQ_BROKER || defaults.host,
@@ -94,6 +101,7 @@ const resolveDefaultBrokerConfig = () => {
     password: Bun.env.TERMOTTQ_PASSWORD || defaults.password,
     tls: Bun.env.TERMOTTQ_TLS === "true" || defaults.tls,
     topicFilter: rootTopic,
+    topicFilters: extraTopics,
     defaultTopic: rootTopic,
   };
 };

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,6 +28,18 @@ describe("parseArgs", () => {
     expect(result.upgrade).toBe(true);
     expect(result.yes).toBe(true);
   });
+
+  test("parses multiple root topics", () => {
+    const result = parseArgs(["-r", "sensors/#", "-r", "devices/#", "-r", "alerts/#"]);
+    expect(result.overrides.rootTopic).toBe("sensors/#");
+    expect(result.overrides.extraTopics).toEqual(["devices/#", "alerts/#"]);
+  });
+
+  test("single root topic produces no extraTopics", () => {
+    const result = parseArgs(["-r", "sensors/#"]);
+    expect(result.overrides.rootTopic).toBe("sensors/#");
+    expect(result.overrides.extraTopics).toBeUndefined();
+  });
 });
 
 describe("matchesPattern", () => {


### PR DESCRIPTION
Closes #3

Subscribe to multiple MQTT topic filters at once.

- New **Extra topics (comma-sep)** field in the Broker dialog
- Repeat `-r` / `--root-topic` on the CLI for multiple topics
- Status bar shows `host:port (N topics)` when multiple filters active
- `TERMOTTQ_EXTRA_TOPICS` env var support
- Backward compatible — existing `topicFilter` unchanged